### PR TITLE
Sync ipynb np.logspace() params with online quiz params

### DIFF
--- a/course-2/week-4-ridge-regression-assignment-1-blank.ipynb
+++ b/course-2/week-4-ridge-regression-assignment-1-blank.ipynb
@@ -501,7 +501,7 @@
    "source": [
     "Once we have a function to compute the average validation error for a model, we can write a loop to find the model that minimizes the average validation error. Write a loop that does the following:\n",
     "* We will again be aiming to fit a 15th-order polynomial model using the `sqft_living` input\n",
-    "* For `l2_penalty` in [10^1, 10^1.5, 10^2, 10^2.5, ..., 10^7] (to get this in Python, you can use this Numpy function: `np.logspace(1, 7, num=13)`.)\n",
+    "* For `l2_penalty` in [10^1, 10^1.5, 10^2, 10^2.5, ..., 10^7] (to get this in Python, you can use this Numpy function: `np.logspace(3, 9, num=13)`.)\n",
     "    * Run 10-fold cross-validation with `l2_penalty`\n",
     "* Report which L2 penalty produced the lowest average validation error.\n",
     "\n",


### PR DESCRIPTION
Change `np.logspace(1, 7, num=13)` in the [ipython notebook](https://github.com/learnml/machine-learning-specialization/edit/master/course-2/week-4-ridge-regression-assignment-1-blank.ipynb#L524) on line 504 to `np.logspace(3, 9, num=13)` to match the assignment quiz question.

Using the current `np.logspace(1, 7, num=13)` in this notebook will give an incorrect answer, whereas `np.logspace(3, 9, num=13)` from the online assignment page will give the correct quiz answer.