### PR TITLE
Fix a typo in module-6-decision-tree-practical-assignment-blank.ipynb

### DIFF
--- a/course-3/module-6-decision-tree-practical-assignment-blank.ipynb
+++ b/course-3/module-6-decision-tree-practical-assignment-blank.ipynb
@@ -664,7 +664,7 @@
     "else:\n",
     "    print 'Test failed... try again!'\n",
     "    print 'Number of nodes found                :', count_nodes(small_decision_tree)\n",
-    "    print 'Number of nodes that should be there : 5' "
+    "    print 'Number of nodes that should be there : 7' "
    ]
   },
   {


### PR DESCRIPTION
As reported here: https://www.coursera.org/learn/ml-classification/module/ahoC8/discussions/cVzQ9foaEeWnyw45DXyCTw
The correct number of nodes should be 7, but the message says that the
correct number of nodes is 5.