### PR TITLE
Remove inapplicable comments in module-8-boosting-assignment-2-blank.ipynb

### DIFF
--- a/course-3/module-8-boosting-assignment-2-blank.ipynb
+++ b/course-3/module-8-boosting-assignment-2-blank.ipynb
@@ -385,8 +385,6 @@
    },
    "outputs": [],
    "source": [
-    "# If the data is identical in each feature, this function should return None\n",
-    "\n",
     "def best_splitting_feature(data, features, target, data_weights):\n",
     "    \n",
     "    # These variables will keep track of the best feature and the corresponding error\n",
@@ -563,7 +561,6 @@
     "        print \"Reached maximum depth. Stopping for now.\"\n",
     "        return create_leaf(target_values, data_weights)\n",
     "    \n",
-    "    # If all the datapoints are the same, splitting_feature will be None. Create a leaf\n",
     "    splitting_feature = best_splitting_feature(data, features, target, data_weights)\n",
     "    remaining_features.remove(splitting_feature)\n",
     "        \n",


### PR DESCRIPTION
As reported here: https://www.coursera.org/learn/ml-classification/discussions/6geAeAyREeavcw5bns7DCQ
best_splitting_feature() does not return None if the data are identical
in each feature. Remove the comment next to the start of best_splitting_feature()
saying that it does. Also remove the comment in weighted_decision_tree_create()
saying that splitting_feature will be None if all the data points are the
same.