### PR TITLE
Distinguish penalized log likelihood

### DIFF
--- a/course-3/module-4-linear-classifier-regularization-assignment-blank.ipynb
+++ b/course-3/module-4-linear-classifier-regularization-assignment-blank.ipynb
@@ -425,12 +425,12 @@
     "            ## YOUR CODE HERE\n",
     "            ...\n",
     "        \n",
-    "        # Checking whether log likelihood is increasing\n",
+    "        # Checking whether the penalized log likelihood is increasing\n",
     "        if itr <= 15 or (itr <= 100 and itr % 10 == 0) or (itr <= 1000 and itr % 100 == 0) \\\n",
     "        or (itr <= 10000 and itr % 1000 == 0) or itr % 10000 == 0:\n",
     "            lp = compute_log_likelihood_with_L2(feature_matrix, sentiment, coefficients, l2_penalty)\n",
-    "            print 'iteration %*d: log likelihood of observed labels = %.8f' % \\\n",
-    "                (int(np.ceil(np.log10(max_iter))), itr, lp)\n",
+    "            print 'iteration %*d: %s of observed labels = %.8f' % \\\n",
+    "                (int(np.ceil(np.log10(max_iter))), itr, 'penalized log likelihood' if l2_penalty > 0 else 'log likelihood', lp)\n",
     "    return coefficients"
    ]
   },
@@ -440,7 +440,7 @@
    "source": [
     "# Explore effects of L2 regularization\n",
     "\n",
-    "Now that we have written up all the pieces needed for regularized logistic regression, let's explore the benefits of using **L2 regularization** in analyzing sentiment for product reviews. **As iterations pass, the log likelihood should increase**.\n",
+    "Now that we have written up all the pieces needed for regularized logistic regression, let's explore the benefits of using **L2 regularization** in analyzing sentiment for product reviews. **As iterations pass, the penalized log likelihood should increase**.\n",
     "\n",
     "Below, we train models with increasing amounts of regularization, starting with no L2 penalty, which is equivalent to our previous logistic regression implementation."
    ]


### PR DESCRIPTION
As discussed here:
https://www.coursera.org/learn/ml-classification/discussions/qFKLfxO8Eea0FgrDsuIyMQ/replies/T09NSRSCEeaqig5uXwUeGw/comments/Rj4FbhYWEeaotQoPyNtt_Q
.. it could be confusing to refer to the penalized log likelihood (log
likelihood less the L2 penalty) as "log likelihood".