### PR TITLE
Fix NameError: name 'obama' is not defined

### DIFF
--- a/course-4/0_nearest-neighbors-features-and-metrics_blank.ipynb
+++ b/course-4/0_nearest-neighbors-features-and-metrics_blank.ipynb
@@ -897,6 +897,7 @@
    },
    "outputs": [],
    "source": [
+    "obama = wiki[wiki['name'] == 'Barack Obama']\n",
     "obama"
    ]
   },
@@ -915,7 +916,6 @@
    },
    "outputs": [],
    "source": [
-    "obama = wiki[wiki['name'] == 'Barack Obama']\n",
     "obama_tf_idf = obama[0]['tf_idf']\n",
     "graphlab.toolkits.distances.cosine(obama_tf_idf, tweet_tf_idf)"
    ]


### PR DESCRIPTION
This moves the definition of `obama' to the code cell where it is first
used.