### PR TITLE
Fix DeprecationWarning seen if using scikit-learn 0.17.0

### DIFF
--- a/course-4/2_kmeans-with-text-data_blank.ipynb
+++ b/course-4/2_kmeans-with-text-data_blank.ipynb
@@ -1320,7 +1320,7 @@
     "        if display_content:\n",
     "            # Compute distances from the centroid to all data points in the cluster,\n",
     "            # and compute nearest neighbors of the centroids within the cluster.\n",
-    "            distances = pairwise_distances(tf_idf, centroids[c], metric='euclidean').flatten()\n",
+    "            distances = pairwise_distances(tf_idf, centroids[c].reshape(1, -1), metric='euclidean').flatten()\n",
     "            distances[cluster_assignment!=c] = float('inf') # remove non-members from consideration\n",
     "            nearest_neighbors = distances.argsort()\n",
     "            # For 8 nearest neighbors, print the title as well as first 180 characters of text.\n",


### PR DESCRIPTION
visualize_document_clusters() produces warnings if using scikit-learn 0.17.0:

> sklearn/utils/validation.py:386: DeprecationWarning: Passing 1d arrays as data is deprecated in 0.17 and willraise ValueError in 0.19. Reshape your data either using X.reshape(-1, 1) if your data has a single feature or X.reshape(1, -1) if it contains a single sample.

The problematic line is the call to pairwise_distances() because the shape of `centroids[c]` is (547979,).

Per the suggestion in the warning message, use `centroids[c].reshape(1, -1)` instead.