### PR TITLE
Fix summation bounds

### DIFF
--- a/course-3/module-10-online-learning-assignment-blank.ipynb
+++ b/course-3/module-10-online-learning-assignment-blank.ipynb
@@ -416,18 +416,18 @@
     "\n",
     "Stochastic gradient estimates the ascent direction using 1 data point, while gradient uses $N$ data points to decide how to update the the parameters.  In an optional video, we discussed the details of a simple change that allows us to use a **mini-batch** of $B \\leq N$ data points to estimate the ascent direction. This simple approach is faster than regular gradient but less noisy than stochastic gradient that uses only 1 data point. Although we encorage you to watch the optional video on the topic to better understand why mini-batches help stochastic gradient, in this assignment, we will simply use this technique, since the approach is very simple and will improve your results.\n",
     "\n",
-    "Given a mini-batch (or a set of data points) $\\mathbf{x}_{i}, \\mathbf{x}_{i+1} \\ldots \\mathbf{x}_{i+B}$, the gradient function for this mini-batch of data points is given by:\n",
+    "Given a mini-batch (or a set of data points) $\\mathbf{x}_{i}, \\mathbf{x}_{i+1} \\ldots \\mathbf{x}_{i+B-1}$, the gradient function for this mini-batch of data points is given by:\n",
     "$$\n",
-    "\\color{red}{\\sum_{s = i}^{i+B}} \\frac{\\partial\\ell_{s}}{\\partial w_j} = \\color{red}{\\sum_{s = i}^{i + B}} h_j(\\mathbf{x}_s)\\left(\\mathbf{1}[y_s = +1] - P(y_s = +1 | \\mathbf{x}_s, \\mathbf{w})\\right)\n",
+    "\\color{red}{\\sum_{s = i}^{i+B-1}} \\frac{\\partial\\ell_{s}}{\\partial w_j} = \\color{red}{\\sum_{s = i}^{i + B - 1}} h_j(\\mathbf{x}_s)\\left(\\mathbf{1}[y_s = +1] - P(y_s = +1 | \\mathbf{x}_s, \\mathbf{w})\\right)\n",
     "$$\n",
     "\n",
     "\n",
     "** Computing the gradient for a \"mini-batch\" of data points**\n",
     "\n",
-    "Using NumPy, we access the points $\\mathbf{x}_i, \\mathbf{x}_{i+1} \\ldots \\mathbf{x}_{i+B}$ in the training data using `feature_matrix_train[i:i+B,:]`\n",
+    "Using NumPy, we access the points $\\mathbf{x}_i, \\mathbf{x}_{i+1} \\ldots \\mathbf{x}_{i+B-1}$ in the training data using `feature_matrix_train[i:i+B,:]`\n",
     "and $y_i$ in the training data using `sentiment_train[i:i+B]`. \n",
     "\n",
-    "We can compute $\\color{red}{\\sum_{s = i}^{i+B}} \\partial\\ell_{s}/\\partial w_j$ easily as follows:"
+    "We can compute $\\color{red}{\\sum_{s = i}^{i+B-1}} \\partial\\ell_{s}/\\partial w_j$ easily as follows:"
    ]
   },
   {
@@ -457,7 +457,7 @@
    "metadata": {},
    "source": [
     "** Quiz Question:** The code block above computed \n",
-    "$\\color{red}{\\sum_{s = i}^{i+B}}\\partial\\ell_{s}(\\mathbf{w})/{\\partial w_j}$ \n",
+    "$\\color{red}{\\sum_{s = i}^{i+B-1}}\\partial\\ell_{s}(\\mathbf{w})/{\\partial w_j}$ \n",
     "for `j = 10`, `i = 10`, and `B = 10`. Is this a scalar or a 194-dimensional vector?\n",
     "\n",
     "\n",
@@ -476,7 +476,7 @@
     "It is a common practice to normalize the gradient update rule by the batch size B:\n",
     "\n",
     "$$\n",
-    "\\frac{\\partial\\ell_{\\color{red}{A}}(\\mathbf{w})}{\\partial w_j} \\approx \\color{red}{\\frac{1}{B}} {\\sum_{s = i}^{i + B}} h_j(\\mathbf{x}_s)\\left(\\mathbf{1}[y_s = +1] - P(y_s = +1 | \\mathbf{x}_s, \\mathbf{w})\\right)\n",
+    "\\frac{\\partial\\ell_{\\color{red}{A}}(\\mathbf{w})}{\\partial w_j} \\approx \\color{red}{\\frac{1}{B}} {\\sum_{s = i}^{i + B - 1}} h_j(\\mathbf{x}_s)\\left(\\mathbf{1}[y_s = +1] - P(y_s = +1 | \\mathbf{x}_s, \\mathbf{w})\\right)\n",
     "$$\n",
     "In other words, we update the coefficients using the **average gradient over data points** (instead of using a summation). By using the average gradient, we ensure that the magnitude of the gradient is approximately the same for all batch sizes. This way, we can more easily compare various batch sizes of stochastic gradient ascent (including a batch size of **all the data points**), and study the effect of batch size on the algorithm as well as the choice of step size.\n",
     "\n",


### PR DESCRIPTION
As reported here:
https://www.coursera.org/learn/ml-classification/discussions/weeks/7/threads/LwlbwEmmEeaQYwrcKTQWAQ
.. the bounds of the summations for a mini-batch should be from i to
i+B-1. This summation has exactly (i+B-1) - i + 1 = B terms.
