### PR TITLE
Updated documentation link

### DIFF
--- a/course-3/module-5-decision-tree-assignment-1-blank.ipynb
+++ b/course-3/module-5-decision-tree-assignment-1-blank.ipynb
@@ -410,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As noted in the [documentation](https://dato.com/products/create/docs/generated/graphlab.boosted_trees_classifier.create.html#graphlab.boosted_trees_classifier.create), typically the max depth of the tree is capped at 6. However, such a tree can be hard to visualize graphically.  Here, we instead learn a smaller model with **max depth of 2** to gain some intuition by visualizing the learned tree."
+    "As noted in the [documentation](https://turi.com/products/create/docs/generated/graphlab.boosted_trees_classifier.create.html#graphlab.boosted_trees_classifier.create), typically the max depth of the tree is capped at 6. However, such a tree can be hard to visualize graphically.  Here, we instead learn a smaller model with **max depth of 2** to gain some intuition by visualizing the learned tree."
    ]
   },
   {


### PR DESCRIPTION
Updated the link for boosted trees documentation to point to turi.com instead of dato.com, dato security certificate has expired.