### PR TITLE
Fixing graphlab upgrade link and homogenizing related text

### DIFF
--- a/course-3/module-10-online-learning-assignment-blank.ipynb
+++ b/course-3/module-10-online-learning-assignment-blank.ipynb
@@ -26,7 +26,7 @@
     "```\n",
     "   pip install graphlab-create --upgrade\n",
     "```\n",
-    "See [this page](https://dato.com/download/) for detailed instructions on upgrading."
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-2-linear-classifier-assignment-blank.ipynb
+++ b/course-3/module-2-linear-classifier-assignment-blank.ipynb
@@ -683,7 +683,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For each review, we will use the **word_count** column and trim out all words that are **not** in the **significant_words** list above. We will use the [SArray dictionary trim by keys functionality]( https://dato.com/products/create/docs/generated/graphlab.SArray.dict_trim_by_keys.html). Note that we are performing this on both the training and test set."
+    "For each review, we will use the **word_count** column and trim out all words that are **not** in the **significant_words** list above. We will use the [SArray dictionary trim by keys functionality]( https://turi.com/products/create/docs/generated/graphlab.SArray.dict_trim_by_keys.html). Note that we are performing this on both the training and test set."
    ]
   },
   {

--- a/course-3/module-2-linear-classifier-assignment-blank.ipynb
+++ b/course-3/module-2-linear-classifier-assignment-blank.ipynb
@@ -28,7 +28,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make sure you have the latest version of GraphLab Create."
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
+    "\n",
+    "```\n",
+    "   pip install graphlab-create --upgrade\n",
+    "```\n",
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-3-linear-classifier-learning-assignment-blank.ipynb
+++ b/course-3/module-3-linear-classifier-learning-assignment-blank.ipynb
@@ -24,7 +24,7 @@
     "```\n",
     "   pip install graphlab-create --upgrade\n",
     "```\n",
-    "See [this page](https://dato.com/download/) for detailed instructions on upgrading."
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-4-linear-classifier-regularization-assignment-blank.ipynb
+++ b/course-3/module-4-linear-classifier-regularization-assignment-blank.ipynb
@@ -21,7 +21,7 @@
     "```\n",
     "   pip install graphlab-create --upgrade\n",
     "```\n",
-    "See [this page](https://dato.com/download/) for detailed instructions on upgrading."
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-5-decision-tree-assignment-1-blank.ipynb
+++ b/course-3/module-5-decision-tree-assignment-1-blank.ipynb
@@ -28,18 +28,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fire up GraphLab Create"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make sure you have the latest version of GraphLab Create. If you don't find the decision tree module, then you would need to upgrade GraphLab Create using\n",
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
     "\n",
     "```\n",
     "   pip install graphlab-create --upgrade\n",
-    "```"
+    "```\n",
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-5-decision-tree-assignment-2-blank.ipynb
+++ b/course-3/module-5-decision-tree-assignment-2-blank.ipynb
@@ -33,14 +33,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fire up GraphLab Create"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make sure you have the latest version of GraphLab Create."
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
+    "\n",
+    "```\n",
+    "   pip install graphlab-create --upgrade\n",
+    "```\n",
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-6-decision-tree-practical-assignment-blank.ipynb
+++ b/course-3/module-6-decision-tree-practical-assignment-blank.ipynb
@@ -26,14 +26,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fire up GraphLab Create"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make sure you have the latest version of GraphLab Create."
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
+    "\n",
+    "```\n",
+    "   pip install graphlab-create --upgrade\n",
+    "```\n",
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-8-boosting-assignment-1-blank.ipynb
+++ b/course-3/module-8-boosting-assignment-1-blank.ipynb
@@ -22,7 +22,14 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "## Fire up Graphlab Create"
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
+    "\n",
+    "```\n",
+    "   pip install graphlab-create --upgrade\n",
+    "```\n",
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-8-boosting-assignment-1-blank.ipynb
+++ b/course-3/module-8-boosting-assignment-1-blank.ipynb
@@ -282,7 +282,7 @@
     "Gradient boosted trees are a powerful variant of boosting methods; they have been used to win many [Kaggle](https://www.kaggle.com/) competitions, and have been widely used in industry.  We will explore the predictive power of multiple decision trees as opposed to a single decision tree.\n",
     "\n",
     "**Additional reading:** If you are interested in gradient boosted trees, here is some additional reading material:\n",
-    "* [GraphLab Create user guide](https://dato.com/learn/userguide/supervised-learning/boosted_trees_classifier.html)\n",
+    "* [GraphLab Create user guide](https://turi.com/learn/userguide/supervised-learning/boosted_trees_classifier.html)\n",
     "* [Advanced material on boosted trees](http://homes.cs.washington.edu/~tqchen/pdf/BoostedTree.pdf)\n",
     "\n",
     "\n",

--- a/course-3/module-8-boosting-assignment-2-blank.ipynb
+++ b/course-3/module-8-boosting-assignment-2-blank.ipynb
@@ -25,18 +25,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fire up GraphLab Create"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make sure you have the latest version of GraphLab Create **(1.8.3 or newer)**. Upgrade by\n",
+    "# Fire up GraphLab Create\n",
+    " \n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
+    "\n",
     "```\n",
     "   pip install graphlab-create --upgrade\n",
     "```\n",
-    "See [this page](https://dato.com/download/) for detailed instructions on upgrading."
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {

--- a/course-3/module-9-precision-recall-assignment-blank.ipynb
+++ b/course-3/module-9-precision-recall-assignment-blank.ipynb
@@ -16,12 +16,12 @@
     " \n",
     "Because we are using the full Amazon review dataset (not a subset of words or reviews), in this assignment we return to using GraphLab Create for its efficiency. As usual, let's start by **firing up GraphLab Create**.\n",
     "\n",
-    "Make sure you have the latest version of GraphLab Create (1.8.3 or later). If you don't find the decision tree module, then you would need to upgrade graphlab-create using\n",
+    "Make sure you have the latest version of GraphLab Create. Upgrade by\n",
     "\n",
     "```\n",
     "   pip install graphlab-create --upgrade\n",
     "```\n",
-    "See [this page](https://dato.com/download/) for detailed instructions on upgrading."
+    "See [this page](https://turi.com/download/upgrade-graphlab-create.html) for detailed instructions on upgrading."
    ]
   },
   {


### PR DESCRIPTION
Some of the assignments have an incorrect URL for instructions on upgrading graphlab-create. These changes fix the URL and also make the instructions uniform across all the assignments.

See https://www.coursera.org/learn/ml-classification/discussions/all/threads/hiOUFSTWEeiNxg4aXnAAXA